### PR TITLE
feat: 게시글 카드 레이아웃 개선 및 썸네일 위치 변경 (#43)

### DIFF
--- a/src/features/posts/components/PostCard.tsx
+++ b/src/features/posts/components/PostCard.tsx
@@ -18,25 +18,7 @@ export default function PostCard({
   searchKeyword?: string;
 }) {
   return (
-    <article className="flex flex-col gap-4 rounded-lg bg-white py-4 md:flex-row md:items-center md:gap-6 md:py-6">
-      {/* 썸네일 영역 - 모바일에서는 위쪽에 표시 */}
-      <div className="relative h-48 w-full shrink-0 md:h-32 md:w-44">
-        {post.thumbnailImageUrl ? (
-          <Image
-            src={post.thumbnailImageUrl}
-            alt={`${post.title} 썸네일`}
-            fill
-            className="rounded-lg object-cover md:rounded-2xl"
-            sizes="(max-width: 768px) 100vw, 176px"
-            quality={75}
-            loading="lazy"
-            unoptimized={post.thumbnailImageUrl.includes(".svg")}
-          />
-        ) : (
-          <div className="h-full w-full shrink-0 rounded-lg bg-gray-100 md:rounded-2xl" />
-        )}
-      </div>
-
+    <article className="flex flex-row items-start gap-3 rounded-lg bg-white py-4 md:items-center md:gap-6 md:py-6">
       {/* 콘텐츠 영역 */}
       <div className="flex-1 md:h-[140px] md:w-[500px]">
         <PostLink
@@ -57,6 +39,24 @@ export default function PostCard({
           date={post.createdAt ? new Date(post.createdAt).toISOString().split("T")[0] : ""}
           tags={post.tags ?? []}
         />
+      </div>
+
+      {/* 썸네일 영역 - 모바일과 데스크톱 모두 우측에 표시 */}
+      <div className="relative h-20 w-28 shrink-0 md:h-32 md:w-44">
+        {post.thumbnailImageUrl ? (
+          <Image
+            src={post.thumbnailImageUrl}
+            alt={`${post.title} 썸네일`}
+            fill
+            className="rounded-lg object-cover md:rounded-2xl"
+            sizes="(max-width: 768px) 80px, 176px"
+            quality={75}
+            loading="lazy"
+            unoptimized={post.thumbnailImageUrl.includes(".svg")}
+          />
+        ) : (
+          <div className="h-full w-full shrink-0 rounded-lg bg-gray-100 md:rounded-2xl" />
+        )}
       </div>
     </article>
   );

--- a/src/features/posts/components/PostCard.tsx
+++ b/src/features/posts/components/PostCard.tsx
@@ -49,7 +49,7 @@ export default function PostCard({
             alt={`${post.title} 썸네일`}
             fill
             className="rounded-lg object-cover md:rounded-2xl"
-            sizes="(max-width: 768px) 80px, 176px"
+            sizes="(max-width: 768px) 112px, 176px"
             quality={75}
             loading="lazy"
             unoptimized={post.thumbnailImageUrl.includes(".svg")}


### PR DESCRIPTION
- 썸네일 위치를 좌측에서 우측으로 이동
- 모바일과 데스크톱 레이아웃 통일 (가로 배치)
- 모바일 썸네일 크기 최적화 및 상단 정렬 적용
- 반응형 디자인 개선으로 일관된 사용자 경험 제공

- Related to #43 