### PR TITLE
feat: ChatBotWindow 반응형 디자인 구현 (#43)

### DIFF
--- a/src/features/chatbot/components/ChatBotWindow.tsx
+++ b/src/features/chatbot/components/ChatBotWindow.tsx
@@ -53,7 +53,13 @@ export default function ChatBotWindow({ isOpen }: ChatBotWindowProps) {
   };
 
   const baseWindowClass =
-    "fixed right-6 bottom-[100px] z-[9998] flex h-[56.29vh] max-h-[900px] min-h-[600px] w-[23.45vw] max-w-[600px] min-w-[400px] flex-col rounded-3xl bg-white shadow-[0_0_24px_9px_rgba(33,37,40,0.06)] transition-all duration-300 ease-in-out";
+    "fixed right-6 bottom-[100px] z-[9998] flex flex-col rounded-3xl bg-white shadow-[0_0_24px_9px_rgba(33,37,40,0.06)] transition-all duration-300 ease-in-out " +
+    // 모바일 크기
+    "h-[70vh] w-[90vw] min-h-[400px] min-w-[280px] max-h-[500px] max-w-[350px] " +
+    // 태블릿 크기
+    "sm:h-[60vh] sm:w-[50vw] sm:min-h-[500px] sm:min-w-[350px] sm:max-h-[600px] sm:max-w-[450px] " +
+    // 데스크톱 크기
+    "lg:h-[56.29vh] lg:w-[23.45vw] lg:min-h-[600px] lg:min-w-[400px] lg:max-h-[900px] lg:max-w-[600px]";
 
   return (
     <div


### PR DESCRIPTION
- 모바일, 태블릿, 데스크톱 화면 크기별 적응형 레이아웃 적용
- 모바일: 90vw × 70vh (최소 280×400px, 최대 350×500px)
- 태블릿: 50vw × 60vh (최소 350×500px, 최대 450×600px)
- 데스크톱: 23.45vw × 56.29vh (최소 400×600px, 최대 600×900px)

- Related to #43 