### PR TITLE
feat: 조건부 프로필 라우팅 및 Button 디자인 시스템 통일 (#51)

### DIFF
--- a/src/app/(dashboard)/loading.tsx
+++ b/src/app/(dashboard)/loading.tsx
@@ -8,7 +8,7 @@
  * (dashboard) 그룹 내의 모든 페이지에서 사용됩니다.
  */
 
-import MyPageSkeleton from "@/components/shared/skeletons/MyPageSkeleton";
+import MyPageSidebarSkeleton from "../../components/shared/skeletons/MyPageSidebarSkeleton";
 
 export default function DashboardLoading() {
   return (
@@ -17,7 +17,7 @@ export default function DashboardLoading() {
       <div className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
         {/* 마이페이지용 스켈레톤 UI 사용 */}
         <div className="flex gap-4">
-          <MyPageSkeleton />
+          <MyPageSidebarSkeleton />
 
           {/* 탭 영역 스켈레톤 */}
           <div className="flex-1">

--- a/src/app/(dashboard)/profile/[username]/loading.tsx
+++ b/src/app/(dashboard)/profile/[username]/loading.tsx
@@ -5,8 +5,8 @@
  * 기존 마이페이지와 동일한 레이아웃 구조를 유지합니다.
  */
 
-import { MyPageSkeleton } from "@/components/shared";
+import MyPageSidebarSkeleton from "../../../../components/shared/skeletons/MyPageSidebarSkeleton";
 
 export default function PublicProfileLoading() {
-  return <MyPageSkeleton />;
+  return <MyPageSidebarSkeleton />;
 }

--- a/src/app/(dashboard)/profile/[username]/page.tsx
+++ b/src/app/(dashboard)/profile/[username]/page.tsx
@@ -11,6 +11,25 @@ import { ProfileLayout } from "@/components/shared";
 import { getPublicUser } from "@/features/user/services/userService";
 import { notFound } from "next/navigation";
 
+/**
+ * 페이지 메타데이터 생성
+ */
+export async function generateMetadata({ params }: PublicProfilePageProps) {
+  const { username } = await params;
+  const userProfile = await getPublicUser(username);
+
+  if (!userProfile) {
+    return {
+      title: "사용자를 찾을 수 없습니다",
+    };
+  }
+
+  return {
+    title: `${userProfile.profile?.nickname}님의 프로필`,
+    description: `${userProfile.profile?.nickname}님이 작성한 게시글을 확인해보세요.`,
+  };
+}
+
 interface PublicProfilePageProps {
   params: Promise<{
     username: string;
@@ -31,23 +50,4 @@ export default async function PublicProfilePage({ params }: PublicProfilePagePro
   }
 
   return <ProfileLayout mode="public" username={username} />;
-}
-
-/**
- * 페이지 메타데이터 생성
- */
-export async function generateMetadata({ params }: PublicProfilePageProps) {
-  const { username } = await params;
-  const userProfile = await getPublicUser(username);
-
-  if (!userProfile) {
-    return {
-      title: "사용자를 찾을 수 없습니다",
-    };
-  }
-
-  return {
-    title: `${userProfile.profile?.nickname}님의 프로필`,
-    description: `${userProfile.profile?.nickname}님이 작성한 게시글을 확인해보세요.`,
-  };
 }

--- a/src/components/shared/ProfileActions.tsx
+++ b/src/components/shared/ProfileActions.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { useAuth } from "@/hooks/useAuth";
+import Link from "next/link";
+
+interface ProfileActionsProps {
+  targetUsername: string;
+  mode: "mypage" | "public";
+}
+
+/**
+ * 프로필 페이지에서 사용되는 액션 버튼들
+ *
+ * 본인 프로필을 공개 프로필 페이지에서 볼 때 마이페이지로 이동할 수 있는 버튼 제공
+ */
+export const ProfileActions = ({ targetUsername, mode }: ProfileActionsProps) => {
+  const { userProfile } = useAuth();
+  const isMyProfile = userProfile?.nickname === targetUsername;
+
+  // 마이페이지에서는 추가 액션 불필요
+  if (mode === "mypage") {
+    return null;
+  }
+
+  // 공개 프로필에서 본인 프로필을 보는 경우
+  if (mode === "public" && isMyProfile) {
+    return (
+      <div className="mt-4 flex justify-center">
+        <Link href="/mypage">
+          <Button variant="outline" size="sm">
+            마이페이지로 이동
+          </Button>
+        </Link>
+      </div>
+    );
+  }
+
+  return null;
+};

--- a/src/components/shared/ProfileLink.tsx
+++ b/src/components/shared/ProfileLink.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { useAuth } from "@/hooks/useAuth";
+import Link from "next/link";
+import { ReactNode } from "react";
+
+interface ProfileLinkProps {
+  nickname: string;
+  children: ReactNode;
+  className?: string;
+  showTooltip?: boolean;
+}
+
+/**
+ * 프로필 링크 컴포넌트
+ *
+ * 본인 프로필인 경우 /mypage로, 타인 프로필인 경우 /profile/[nickname]으로 이동
+ * 일관된 UX를 제공하기 위한 조건부 라우팅 구현
+ */
+export const ProfileLink = ({
+  nickname,
+  children,
+  className,
+  showTooltip = false,
+}: ProfileLinkProps) => {
+  const { userProfile } = useAuth();
+  const isMyProfile = userProfile?.nickname === nickname;
+
+  // 본인 프로필이면 마이페이지로, 타인이면 공개 프로필로
+  const href = isMyProfile ? "/mypage" : `/profile/${nickname}`;
+  const tooltipText = isMyProfile ? "마이페이지로 이동" : `${nickname}의 프로필 보기`;
+
+  return (
+    <Link href={href} className={className} title={showTooltip ? tooltipText : undefined}>
+      {children}
+    </Link>
+  );
+};

--- a/src/components/shared/ProfileRedirect.tsx
+++ b/src/components/shared/ProfileRedirect.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { useAuth } from "@/hooks/useAuth";
+import { useRouter } from "next/navigation";
+import { useEffect } from "react";
+
+interface ProfileRedirectProps {
+  targetUsername: string;
+}
+
+/**
+ * 공개 프로필 페이지에서 본인 프로필 접근 시 마이페이지로 자동 리다이렉트
+ *
+ * URL을 직접 입력하거나 링크로 접근한 경우에도 일관된 UX 제공
+ */
+export const ProfileRedirect = ({ targetUsername }: ProfileRedirectProps) => {
+  const { userProfile, isLoading } = useAuth();
+  const router = useRouter();
+
+  useEffect(() => {
+    // 로딩이 완료되고 본인 프로필인 경우 마이페이지로 리다이렉트
+    if (!isLoading && userProfile?.nickname === targetUsername) {
+      router.replace("/mypage");
+    }
+  }, [isLoading, userProfile?.nickname, targetUsername, router]);
+
+  // 로딩 중이거나 리다이렉트 처리 중에는 아무것도 렌더링하지 않음
+  return null;
+};

--- a/src/components/shared/ProfileRedirect.tsx
+++ b/src/components/shared/ProfileRedirect.tsx
@@ -22,7 +22,7 @@ export const ProfileRedirect = ({ targetUsername }: ProfileRedirectProps) => {
     if (!isLoading && userProfile?.nickname === targetUsername) {
       router.replace("/mypage");
     }
-  }, [isLoading, userProfile?.nickname, targetUsername, router]);
+  }, [isLoading, userProfile?.nickname, targetUsername]);
 
   // 로딩 중이거나 리다이렉트 처리 중에는 아무것도 렌더링하지 않음
   return null;

--- a/src/components/shared/index.ts
+++ b/src/components/shared/index.ts
@@ -26,5 +26,5 @@ export { default as WelcomeModal } from "./interactive/WelcomeModal";
 
 // Skeletons
 export { default as MainPageSkeleton } from "./skeletons/MainPageSkeleton";
-export { default as MyPageSkeleton } from "./skeletons/MyPageSkeleton";
+export { default as MyPageSidebarSkeleton } from "./skeletons/MyPageSidebarSkeleton";
 export { default as TabContentSkeleton } from "./skeletons/TabContentSkeleton";

--- a/src/components/shared/layout/HeaderNavigation.tsx
+++ b/src/components/shared/layout/HeaderNavigation.tsx
@@ -2,6 +2,7 @@
 
 import { Button } from "@/components/ui/button";
 import { useAuth } from "@/hooks/useAuth";
+import { useLoadingDots } from "@/hooks/useLoadingDots";
 import { DropdownActionItem } from "@/types/dropdown";
 import Image from "next/image";
 import Link from "next/link";
@@ -25,24 +26,9 @@ export const HeaderNavigation = () => {
   const pathname = usePathname(); // 현재 경로 가져오기
 
   const [isAttemptingLogin, setIsAttemptingLogin] = useState(false);
-  const [loginDots, setLoginDots] = useState("");
+  const loginDots = useLoadingDots(isAttemptingLogin);
   const [forceUpdateKey, setForceUpdateKey] = useState(0); // 강제 리렌더링용 상태
   const [searchKeyword, setSearchKeyword] = useState("");
-
-  // 검색 처리 함수
-  const handleSearch = (e: React.FormEvent) => {
-    e.preventDefault();
-    if (searchKeyword.trim()) {
-      router.push(`/search?q=${encodeURIComponent(searchKeyword.trim())}`);
-    }
-  };
-
-  // Enter 키 처리
-  const handleKeyPress = (e: React.KeyboardEvent) => {
-    if (e.key === "Enter") {
-      handleSearch(e);
-    }
-  };
 
   // PRE_REGISTER 역할인 경우 /signup 페이지로 리디렉션
   useEffect(() => {
@@ -71,25 +57,27 @@ export const HeaderNavigation = () => {
   //   );
   // }
 
-  useEffect(() => {
-    let interval: NodeJS.Timeout;
-    if (isAttemptingLogin) {
-      interval = setInterval(() => {
-        setLoginDots((prevDots) => {
-          if (prevDots.length >= 3) return ".";
-          return prevDots + ".";
-        });
-      }, 500); // 0.5초마다 점 변경
-    }
-    return () => clearInterval(interval);
-  }, [isAttemptingLogin]);
-
   const handleLoginClick = () => {
     setIsAttemptingLogin(true);
     // 실제 로그인 로직은 Link href를 통해 GitHub으로 리디렉션되므로,
     // 여기서는 상태 변경만 처리합니다. 페이지 이동 후에는 이 컴포넌트가 언마운트되거나
     // isAttemptingLogin 상태가 초기화될 수 있습니다.
     // 만약 SPA 내에서 직접 API 호출로 로그인한다면, 성공/실패 시 isAttemptingLogin을 false로 설정해야 합니다.
+  };
+
+  // 검색 처리 함수
+  const handleSearch = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (searchKeyword.trim()) {
+      router.push(`/search?q=${encodeURIComponent(searchKeyword.trim())}`);
+    }
+  };
+
+  // Enter 키 처리
+  const handleKeyPress = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter") {
+      handleSearch(e);
+    }
   };
 
   const handleLogout = async () => {
@@ -203,10 +191,7 @@ export const HeaderNavigation = () => {
           // 로그인된 상태: 프로필 이미지 표시
           <>
             <Link href="/posts/new">
-              <Button
-                variant="default" // 기본 variant 사용 또는 커스텀 스타일 유지
-                className={`flex items-center gap-2 rounded-full bg-[#20242B] px-4 py-2 text-xs text-white transition-colors duration-150 sm:text-sm`}
-              >
+              <Button variant="primary" size="rounded">
                 글쓰기
               </Button>
             </Link>
@@ -221,12 +206,8 @@ export const HeaderNavigation = () => {
             passHref
           >
             <Button
-              variant="default" // 기본 variant 사용 또는 커스텀 스타일 유지
-              className={`flex items-center gap-2 rounded-full bg-[#20242B] px-4 py-2 text-xs text-white transition-colors duration-150 sm:text-sm ${
-                isAttemptingLogin
-                  ? "cursor-not-allowed opacity-70"
-                  : "hover:cursor-pointer hover:bg-[#33373E]"
-              }`}
+              variant={isAttemptingLogin ? "primary-loading" : "primary"}
+              size="rounded"
               disabled={isAttemptingLogin}
             >
               {isAttemptingLogin ? (

--- a/src/components/shared/layout/ProfileLayout.tsx
+++ b/src/components/shared/layout/ProfileLayout.tsx
@@ -1,5 +1,7 @@
 import { MyPageTabContent } from "@/features/user";
 import MyPageSidebarServer from "@/features/user/components/mypage/MyPageSidebar.server";
+import { ProfileActions } from "../ProfileActions";
+import { ProfileRedirect } from "../ProfileRedirect";
 
 interface ProfileLayoutProps {
   mode: "mypage" | "public";
@@ -21,14 +23,24 @@ export default function ProfileLayout({ mode, username, children }: ProfileLayou
   const isOwner = mode === "mypage";
 
   return (
-    <div className="mt-10 flex gap-4">
-      {/* 사용자 프로필 사이드바 */}
-      <MyPageSidebarServer isOwner={isOwner} username={username} />
+    <>
+      {/* 공개 프로필에서 본인 프로필 접근 시 자동 리다이렉트 */}
+      {mode === "public" && username && <ProfileRedirect targetUsername={username} />}
 
-      {/* 탭 콘텐츠 - 통합 데이터 관리 */}
-      <MyPageTabContent isOwner={isOwner} username={username} />
+      <div className="mt-10 flex gap-4">
+        {/* 사용자 프로필 사이드바 */}
+        <MyPageSidebarServer isOwner={isOwner} username={username} />
 
-      {children}
-    </div>
+        {/* 탭 콘텐츠 - 통합 데이터 관리 */}
+        <div className="flex-1">
+          <MyPageTabContent isOwner={isOwner} username={username} />
+
+          {/* 추가 프로필 액션 버튼들 */}
+          <ProfileActions targetUsername={username || ""} mode={mode} />
+        </div>
+
+        {children}
+      </div>
+    </>
   );
 }

--- a/src/components/shared/skeletons/MyPageSidebarSkeleton.tsx
+++ b/src/components/shared/skeletons/MyPageSidebarSkeleton.tsx
@@ -6,7 +6,7 @@ import { Skeleton } from "@/components/ui/skeleton";
  * 탭 콘텐츠는 각 탭별 개별 스켈레톤이 처리하므로
  * 사이드바(프로필 정보) 영역만 스켈레톤으로 표시합니다.
  */
-export default function MyPageSkeleton() {
+export default function MyPageSidebarSkeleton() {
   return (
     <aside
       className="flex w-64 flex-col items-center bg-white py-10 pr-8"

--- a/src/components/shared/skeletons/index.ts
+++ b/src/components/shared/skeletons/index.ts
@@ -1,3 +1,3 @@
 export { default as MainPageSkeleton } from "./MainPageSkeleton";
-export { default as MyPageSkeleton } from "./MyPageSkeleton";
+export { default as MyPageSidebarSkeleton } from "./MyPageSidebarSkeleton";
 export { default as TabContentSkeleton } from "./TabContentSkeleton";

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,6 +1,6 @@
-import * as React from "react";
 import { Slot } from "@radix-ui/react-slot";
 import { cva, type VariantProps } from "class-variance-authority";
+import * as React from "react";
 
 import { cn } from "@/lib/utils";
 
@@ -17,12 +17,16 @@ const buttonVariants = cva(
         secondary: "bg-secondary text-secondary-foreground shadow-xs hover:bg-secondary/80",
         ghost: "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
         link: "text-primary underline-offset-4 hover:underline",
+        primary: "bg-[#20242B] text-white hover:bg-[#33373E] transition-colors duration-150",
+        "primary-loading": "bg-[#20242B] text-white opacity-70 cursor-not-allowed",
       },
       size: {
         default: "h-9 px-4 py-2 has-[>svg]:px-3",
         sm: "h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5",
         lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
         icon: "size-9",
+        rounded: "rounded-full px-4 py-2 text-xs sm:text-sm",
+        "rounded-lg": "rounded-3xl px-6 py-2",
       },
     },
     defaultVariants: {

--- a/src/constants/mypageConstants.ts
+++ b/src/constants/mypageConstants.ts
@@ -37,6 +37,6 @@ export const createMyPageStats = (activityStats: UserActivityResponse | null): S
   return MY_PAGE_STATS_DEFINITIONS.map((def) => ({
     ...def,
     // activityStats가 존재하고, 해당 키의 값이 있으면 그 값을 사용, 없으면 0
-    count: activityStats?.[def.key] ?? 0,
+    count: activityStats?.[def.key as keyof UserActivityResponse] ?? 0,
   }));
 };

--- a/src/constants/mypageConstants.ts
+++ b/src/constants/mypageConstants.ts
@@ -1,0 +1,42 @@
+// src/constants/mypageConstants.ts
+
+import { UserActivityResponse } from "../generated/api";
+
+// 각 스탯 아이템의 정적 정보를 정의합니다.
+export const MY_PAGE_STATS_DEFINITIONS = [
+  {
+    key: "writtenPostCount",
+    icon: "/postIcon.svg",
+    alt: "작성 글 아이콘",
+    label: "작성 글",
+  },
+  {
+    key: "writtenCommentCount",
+    icon: "/commentIcon.svg",
+    alt: "작성 댓글 아이콘",
+    label: "작성 댓글",
+  },
+  {
+    key: "likedPostCount",
+    icon: "/likeIcon.svg",
+    alt: "좋아요 아이콘",
+    label: "좋아요",
+  },
+] as const; // as const로 타입 추론을 더 정확하게 만듭니다.
+
+// StatItem 타입을 여기서 정의하거나, src/types/mypage.ts 등에서 가져올 수 있습니다.
+export interface StatItem {
+  icon: string;
+  alt: string;
+  label: string;
+  count: number;
+}
+
+// 정적 정의와 동적 데이터를 조합해 최종 stats 배열을 만드는 생성 함수
+export const createMyPageStats = (activityStats: UserActivityResponse | null): StatItem[] => {
+  return MY_PAGE_STATS_DEFINITIONS.map((def) => ({
+    ...def,
+    // activityStats가 존재하고, 해당 키의 값이 있으면 그 값을 사용, 없으면 0
+    count: activityStats?.[def.key] ?? 0,
+  }));
+};

--- a/src/features/posts/components/PopularPost.tsx
+++ b/src/features/posts/components/PopularPost.tsx
@@ -25,7 +25,9 @@ export default function PopularPost({ postId, title, author, profileImage }: Pop
           ) : (
             <span className="inline-block h-6 w-6 rounded-full bg-gray-200" />
           )}
-          {author}
+          <Link href={`/profile/${author}`} className="hover:text-[#FAA631]">
+            {author}
+          </Link>
         </div>
       </article>
     </Link>

--- a/src/features/posts/components/PostFormActions.tsx
+++ b/src/features/posts/components/PostFormActions.tsx
@@ -2,7 +2,7 @@
 
 import { Button } from "@/components/ui";
 import { UI_CONSTANTS } from "@/constants/ui";
-import { useEffect, useState } from "react";
+import { useLoadingDots } from "@/hooks/useLoadingDots";
 
 interface PostFormActionsProps {
   mode: "create" | "edit";
@@ -10,22 +10,7 @@ interface PostFormActionsProps {
 }
 
 export default function PostFormActions({ mode, isLoading }: PostFormActionsProps) {
-  const [uploadingDots, setUploadingDots] = useState("");
-
-  useEffect(() => {
-    let interval: NodeJS.Timeout;
-    if (isLoading) {
-      interval = setInterval(() => {
-        setUploadingDots((prevDots) => {
-          if (prevDots.length >= 3) return ".";
-          return prevDots + ".";
-        });
-      }, 500);
-    } else {
-      setUploadingDots("");
-    }
-    return () => clearInterval(interval);
-  }, [isLoading]);
+  const uploadingDots = useLoadingDots(isLoading);
 
   const getButtonText = () => {
     if (isLoading) {
@@ -44,9 +29,8 @@ export default function PostFormActions({ mode, isLoading }: PostFormActionsProp
     <div className="flex items-center justify-end gap-3">
       <Button
         type="submit"
-        className={`rounded-4xl bg-[#20242B] px-6 py-2 text-white transition-colors duration-150 ${
-          isLoading ? "cursor-not-allowed opacity-70" : "hover:cursor-pointer hover:bg-[#33373E]/90"
-        }`}
+        variant={isLoading ? "primary-loading" : "primary"}
+        size="rounded-lg"
         disabled={isLoading}
       >
         {getButtonText()}

--- a/src/features/posts/components/PostHeader.tsx
+++ b/src/features/posts/components/PostHeader.tsx
@@ -1,3 +1,4 @@
+import { ProfileLink } from "@/components/shared/ProfileLink";
 import TagBadge from "@/components/ui/TagBadge";
 import { UI_CONSTANTS } from "@/constants/ui";
 import { PostDetailResponse } from "@/generated/api";
@@ -18,24 +19,32 @@ export default function PostHeader({ post, postId, isCurrentUserAuthor = false }
 
       <div className="flex h-12 items-center gap-4 text-[14px]">
         <div className="flex h-5 items-center border-r border-[#B5BBC7] pr-3">
-          {post.writerProfileImageUrl ? (
-            <Image
-              src={post.writerProfileImageUrl}
-              alt={UI_CONSTANTS.ACCESSIBILITY.PROFILE_IMAGE_ALT(post.writer || "사용자")}
-              width={24}
-              height={24}
-              className="h-6 w-6 rounded-full object-cover"
-              priority={true}
-              unoptimized={post.writerProfileImageUrl.includes("amazonaws.com")}
-            />
-          ) : (
-            <div className="flex h-6 w-6 items-center justify-center rounded-full bg-gray-300">
-              <span className="text-xs text-gray-600">
-                {post.writer?.[0]?.toUpperCase() || "?"}
-              </span>
-            </div>
-          )}
-          <span className="ml-2 font-medium text-[#798191]">{post.writer}</span>
+          <ProfileLink nickname={post.writer || ""} showTooltip>
+            {post.writerProfileImageUrl ? (
+              <Image
+                src={post.writerProfileImageUrl}
+                alt={UI_CONSTANTS.ACCESSIBILITY.PROFILE_IMAGE_ALT(post.writer || "사용자")}
+                width={24}
+                height={24}
+                className="h-6 w-6 cursor-pointer rounded-full object-cover transition-all hover:ring-2 hover:ring-[#FAA631]"
+                priority={true}
+                unoptimized={post.writerProfileImageUrl.includes("amazonaws.com")}
+              />
+            ) : (
+              <div className="flex h-6 w-6 cursor-pointer items-center justify-center rounded-full bg-gray-300 transition-all hover:ring-2 hover:ring-[#FAA631]">
+                <span className="text-xs text-gray-600">
+                  {post.writer?.[0]?.toUpperCase() || "?"}
+                </span>
+              </div>
+            )}
+          </ProfileLink>
+          <ProfileLink
+            nickname={post.writer || ""}
+            className="ml-2 font-medium text-[#798191] hover:text-[#FAA631]"
+            showTooltip
+          >
+            {post.writer}
+          </ProfileLink>
         </div>
         <time
           dateTime={

--- a/src/features/user/components/UserActivityStatItem.tsx
+++ b/src/features/user/components/UserActivityStatItem.tsx
@@ -10,7 +10,13 @@ export default function UserActivityStatItem({ icon, label, count }: UserActivit
   return (
     <li className="flex flex-col items-center gap-1">
       {/* alt는 의미를 전달하도록 설정하거나, 장식용 이미지이고 label로 충분하다면 alt="" 또는 aria-hidden="true" 사용 */}
-      <Image src={icon} alt={`${label} 아이콘`} width={23} height={23} />
+      <Image
+        src={icon}
+        alt={`${label} 아이콘`}
+        width={23}
+        height={23}
+        className="h-[23px] w-[23px] object-contain"
+      />
       <span className="mt-1 text-gray-600">{label}</span>
       <span className="text-lg font-semibold">{count}</span>
     </li>

--- a/src/features/user/components/mypage/MyPageSidebar.server.tsx
+++ b/src/features/user/components/mypage/MyPageSidebar.server.tsx
@@ -1,16 +1,12 @@
 import UserIcon from "@/components/ui/UserIcon";
+import { Button } from "@/components/ui/button";
+import { createMyPageStats } from "@/constants/mypageConstants";
 import { UserActivityStatItem } from "@/features/user";
 import ProfileEditDialog from "@/features/user/components/ProfileEditDialog";
 import type { UserActivityResponse, UserProfileResponse } from "@/generated/api";
 import Image from "next/image";
+import Link from "next/link";
 import { createServerApiClient } from "../../../../lib/apiClient";
-
-interface StatItem {
-  icon: string;
-  alt: string;
-  label: string;
-  count: number;
-}
 
 interface MyPageSidebarServerProps {
   isOwner?: boolean;
@@ -58,7 +54,6 @@ export default async function MyPageSidebarServer({
             nickname: publicData.profile.nickname,
             profileImageUrl: publicData.profile.profileImageUrl,
             gamjaBatch: publicData.profile.gamjaBatch,
-            // 공개 프로필에서는 이메일 등 민감한 정보는 제공되지 않음
           } as UserProfileResponse)
         : null;
       activityStats = publicData?.activity || null;
@@ -70,8 +65,7 @@ export default async function MyPageSidebarServer({
     activityStats = null;
   }
 
-  console.log("User Profile:", userProfile);
-  console.log("Activity Stats:", activityStats);
+  const stats = createMyPageStats(activityStats);
 
   // 프로필 데이터가 없는 경우 (인증 실패 등)
   if (!userProfile) {
@@ -89,27 +83,6 @@ export default async function MyPageSidebarServer({
       </aside>
     );
   }
-
-  const stats: StatItem[] = [
-    {
-      icon: "/postIcon.svg",
-      alt: "작성 글 아이콘",
-      label: "작성 글",
-      count: activityStats?.writtenPostCount ?? 0,
-    },
-    {
-      icon: "/commentIcon.svg",
-      alt: "작성 댓글 아이콘",
-      label: "작성 댓글",
-      count: activityStats?.writtenCommentCount ?? 0,
-    },
-    {
-      icon: "/likeIcon.svg",
-      alt: "좋아요 아이콘",
-      label: "좋아요",
-      count: activityStats?.likedPostCount ?? 0,
-    },
-  ];
 
   return (
     <aside className="flex w-64 flex-col items-center py-10 pr-8">
@@ -155,8 +128,23 @@ export default async function MyPageSidebarServer({
           )}
         </div>
 
-        {/* 프로필 수정 Dialog - 소유자에게만 표시 */}
-        {isOwner && userProfile && <ProfileEditDialog userProfile={userProfile} />}
+        {/* 프로필 수정 Dialog 또는 GitHub 방문 버튼 */}
+        {isOwner && userProfile ? (
+          <ProfileEditDialog userProfile={userProfile} />
+        ) : (
+          userProfile?.nickname && (
+            <Link
+              href={`https://github.com/${userProfile.nickname}`}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <Button variant="primary" size="rounded" className="mt-2 flex gap-1.5">
+                <Image src="/githubIcon.svg" alt="GitHub 프로필 방문" width={16} height={16} />
+                <span>GitHub</span>
+              </Button>
+            </Link>
+          )
+        )}
       </section>
 
       {/* 작성 글, 작성 댓글, 좋아요 수 표시 */}

--- a/src/hooks/useLoadingDots.ts
+++ b/src/hooks/useLoadingDots.ts
@@ -1,0 +1,30 @@
+import { useEffect, useState } from "react";
+
+/**
+ * 로딩 상태에서 점 애니메이션을 제공하는 커스텀 훅
+ *
+ * @param isLoading - 로딩 상태
+ * @returns 애니메이션 점 문자열 ("", ".", "..", "...")
+ */
+export const useLoadingDots = (isLoading: boolean): string => {
+  const [dots, setDots] = useState("");
+
+  useEffect(() => {
+    let interval: NodeJS.Timeout;
+
+    if (isLoading) {
+      interval = setInterval(() => {
+        setDots((prevDots) => {
+          if (prevDots.length >= 3) return ".";
+          return prevDots + ".";
+        });
+      }, 500); // 0.5초마다 점 변경
+    } else {
+      setDots("");
+    }
+
+    return () => clearInterval(interval);
+  }, [isLoading]);
+
+  return dots;
+};

--- a/src/hooks/useLoadingDots.ts
+++ b/src/hooks/useLoadingDots.ts
@@ -23,7 +23,9 @@ export const useLoadingDots = (isLoading: boolean): string => {
       setDots("");
     }
 
-    return () => clearInterval(interval);
+    return () => {
+      if (interval) clearInterval(interval);
+    };
   }, [isLoading]);
 
   return dots;


### PR DESCRIPTION
사용자 프로필 접근 UX 개선 및 일관된 버튼 디자인 시스템 구축

- **조건부 프로필 라우팅**: 본인 프로필 클릭 시 `/mypage` 직접 이동
- **자동 리다이렉트**: `/profile/본인닉네임` 접근 시 `/mypage` 자동 이동
- **Button variant 확장**: `primary`, `primary-loading`, `rounded`, `rounded-lg` 추가
- `ProfileLink` 컴포넌트로 조건부 라우팅 통일
- `useLoadingDots` 훅으로 로딩 애니메이션 로직 통일
- 버튼 스타일 통일 (HeaderNavigation, PostFormActions, MyPageSidebar)

- Related to #51 