### PR TITLE
feat: 탭 UX 개선 - URL 파라미터 선택적 보존 및 스타일 개선

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,10 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(yarn build)",
+      "Bash(yarn prettier:*)"
+    ],
+    "deny": [],
+    "ask": []
+  }
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,15 +1,29 @@
 import { DynamicWelcomeModal } from "@/components/dynamic/DynamicComponents";
-import LogoSection from "@/components/shared/layout/LogoSection";
-import SidebarSection from "@/components/shared/layout/SidebarSection.server";
+import ContentLayout from "@/components/shared/layout/ContentLayout";
 import { MainContent, PostListSection, postService } from "@/features/posts";
 import { Metadata } from "next";
 
 export async function generateMetadata({
   searchParams,
 }: {
-  searchParams: Promise<{ tag?: string; page?: string }>;
+  searchParams: Promise<{ tag?: string; page?: string; tab?: string }>;
 }): Promise<Metadata> {
-  const { tag, page } = await searchParams;
+  const { tag, page, tab } = await searchParams;
+
+  // 탭별 메타데이터 처리
+  if (tab === "welcome") {
+    return {
+      title: "텃밭인사 | 감자 기술 블로그",
+      description:
+        "감자 기술 블로그에 새로 온 분들을 위한 텃밭인사 게시판입니다. 자유롭게 인사와 소개를 나눠보세요.",
+      keywords: "인사, 소개, 텃밭인사, 감자, 한세대학교, 개발자 소개",
+      openGraph: {
+        title: "텃밭인사 | 감자 기술 블로그",
+        description: "감자 기술 블로그 텃밭인사 게시판에서 인사를 나눠보세요.",
+        type: "website",
+      },
+    };
+  }
 
   if (tag) {
     return {
@@ -32,12 +46,17 @@ export async function generateMetadata({
     };
   }
 
-  // 기본 메타데이터 (기존 layout.tsx에서 가져옴)
+  // 기본 메타데이터 (모내기 게시판)
   return {
     title: "감자 기술 블로그",
     description:
       "안녕하세요. 감자 기술 블로그입니다. 한세대학교 웹·앱 개발 동아리 감자 구성원들의 지식 공유 공간입니다.",
     keywords: "개발, 기술블로그, 프로그래밍, 감자, 한세대학교, 웹개발, 앱개발",
+    openGraph: {
+      title: "감자 기술 블로그",
+      description: "감자 구성원들의 기술 지식과 경험 공유 공간",
+      type: "website",
+    },
   };
 }
 
@@ -65,26 +84,17 @@ export default async function Home({
     <>
       <DynamicWelcomeModal />
 
-      <div className="layout-stable mx-auto flex flex-col gap-6 md:gap-12">
-        {/* 로고 섹션 - 즉시 렌더링 */}
-        <LogoSection />
-
-        {/* 메인 콘텐츠 - 모바일: 세로 정렬, 데스크톱: 가로 정렬 */}
-        <div className="dynamic-content flex flex-col pb-6 md:flex-row md:pb-10">
-          <MainContent
-            postsTabContent={
-              <PostListSection
-                initialData={homeFeedData.latest}
-                initialTag={tag}
-                initialPage={currentPage}
-              />
-            }
-          />
-
-          {/* 사이드바 섹션 - 모바일에서는 메인 콘텐츠 아래에 표시 */}
-          <SidebarSection popularPosts={homeFeedData.weeklyPopular} tags={homeFeedData.allTags} />
-        </div>
-      </div>
+      <ContentLayout popularPosts={homeFeedData.weeklyPopular} tags={homeFeedData.allTags}>
+        <MainContent
+          postsTabContent={
+            <PostListSection
+              initialData={homeFeedData.latest}
+              initialTag={tag}
+              initialPage={currentPage}
+            />
+          }
+        />
+      </ContentLayout>
     </>
   );
 }

--- a/src/components/shared/layout/ContentLayout.tsx
+++ b/src/components/shared/layout/ContentLayout.tsx
@@ -1,0 +1,28 @@
+import LogoSection from "@/components/shared/layout/LogoSection";
+import SidebarSection from "@/components/shared/layout/SidebarSection.server";
+import { PostPopularResponse } from "@/generated/api";
+import { ReactNode } from "react";
+
+interface ContentLayoutProps {
+  children: ReactNode;
+  popularPosts: PostPopularResponse[] | undefined;
+  tags: string[] | undefined;
+}
+
+export default function ContentLayout({ children, popularPosts, tags }: ContentLayoutProps) {
+  return (
+    <div className="layout-stable mx-auto flex flex-col gap-6 md:gap-12">
+      {/* 로고 섹션 - 즉시 렌더링 */}
+      <LogoSection />
+
+      {/* 메인 콘텐츠 - 모바일: 세로 정렬, 데스크톱: 가로 정렬 */}
+      <div className="dynamic-content flex flex-col pb-6 md:flex-row md:pb-10">
+        {/* 메인 콘텐츠 영역 */}
+        {children}
+
+        {/* 사이드바 섹션 - 모바일에서는 메인 콘텐츠 아래에 표시 */}
+        <SidebarSection popularPosts={popularPosts || []} tags={tags || []} />
+      </div>
+    </div>
+  );
+}

--- a/src/components/shared/navigation/PageNavMenu.tsx
+++ b/src/components/shared/navigation/PageNavMenu.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+interface PageNavMenuProps {
+  labels: Record<string, string>;
+  paths: Record<string, string>;
+}
+
+/**
+ * 페이지 네비게이션 메뉴 컴포넌트
+ *
+ * 탭 대신 링크를 사용하여 페이지 간 이동을 제공합니다.
+ * 현재 경로에 따라 활성 상태를 표시합니다.
+ *
+ * @param labels - 메뉴 라벨 매핑 객체
+ * @param paths - 메뉴 경로 매핑 객체
+ */
+export default function PageNavMenu({ labels, paths }: PageNavMenuProps) {
+  const pathname = usePathname();
+
+  return (
+    <div className="w-full">
+      <nav className="w-full">
+        <ul className="flex w-full justify-evenly border-b border-[#F2F4F6] bg-transparent px-0 pb-3 md:justify-start md:pb-4">
+          {Object.entries(labels).map(([key, label]) => {
+            const path = paths[key];
+            const isActive = pathname === path;
+
+            return (
+              <li key={key}>
+                <Link
+                  href={path}
+                  className={`text-lg hover:cursor-pointer md:border-none md:text-xl ${
+                    isActive
+                      ? "text-primary font-semibold"
+                      : "text-muted-foreground hover:text-foreground"
+                  }`}
+                  aria-current={isActive ? "page" : undefined}
+                >
+                  {label}
+                </Link>
+              </li>
+            );
+          })}
+        </ul>
+      </nav>
+    </div>
+  );
+}

--- a/src/components/shared/navigation/TabMenu.tsx
+++ b/src/components/shared/navigation/TabMenu.tsx
@@ -42,7 +42,7 @@ export default function TabMenu<T extends string>({
               key={value}
               value={value}
               id={`${value}-tab`}
-              className="text-lg md:border-none md:text-xl"
+              className="text-lg hover:cursor-pointer md:border-none md:text-xl"
             >
               {label}
             </TabsTrigger>

--- a/src/features/posts/components/MainContent.tsx
+++ b/src/features/posts/components/MainContent.tsx
@@ -2,10 +2,9 @@
 
 import TabMenu from "@/components/shared/navigation/TabMenu";
 import { WelcomeBoardSection } from "@/features/posts";
-import { useTab } from "@/hooks/useTab"; // Import the generic useTab hook
+import { useTab } from "@/hooks/useTab";
 import { ReactNode } from "react";
 
-// Define MainTab type locally or import if it's defined elsewhere
 type MainTab = "posts" | "welcome";
 const VALID_MAIN_TABS: MainTab[] = ["posts", "welcome"];
 
@@ -18,6 +17,8 @@ export default function MainContent({ postsTabContent }: { postsTabContent: Reac
   const { currentTab, handleTabChange } = useTab<MainTab>({
     defaultTab: "posts",
     validTabs: VALID_MAIN_TABS,
+    queryParamName: "tab",
+    preserveParams: ["tag"], // tag는 유지, page는 초기화됨
   });
 
   const renderTabContent = () => {

--- a/src/features/posts/services/postService.ts
+++ b/src/features/posts/services/postService.ts
@@ -121,4 +121,21 @@ export const postService = {
     const response = await apiClient.getHomeFeed(params || {}, options);
     return response.data as HomeFeedResponse;
   },
+
+  /**
+   * 사이드바 데이터를 조회합니다. (인기 게시글, 태그)
+   */
+  async getSidebarData(
+    options?: RequestInit
+  ): Promise<{ weeklyPopular: PostPopularResponse[]; allTags: string[] }> {
+    const [popularPosts, tags] = await Promise.all([
+      this.getPopularPosts(options),
+      this.getTags(options),
+    ]);
+
+    return {
+      weeklyPopular: popularPosts,
+      allTags: tags,
+    };
+  },
 } as const;

--- a/src/hooks/useTab.ts
+++ b/src/hooks/useTab.ts
@@ -9,6 +9,7 @@ interface UseTabOptions<T extends string> {
   validTabs: T[]; // validTabs is an array of T
   queryParamName?: string; // Default to "tab"
   basePath?: string; // Optional: if the path is not just a query param change
+  preserveParams?: string[]; // Parameters to preserve when tab changes
 }
 
 export function useTab<T extends string>({
@@ -17,6 +18,7 @@ export function useTab<T extends string>({
   validTabs,
   queryParamName = "tab",
   basePath,
+  preserveParams = [],
 }: UseTabOptions<T>) {
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -28,13 +30,25 @@ export function useTab<T extends string>({
 
   const handleTabChange = useCallback(
     (newTab: T) => {
-      // newTab is of type T
-      const params = new URLSearchParams(searchParams.toString());
+      const params = new URLSearchParams();
+
+      // Set the new tab
       params.set(queryParamName, newTab);
+
+      // Preserve specified parameters
+      preserveParams.forEach((paramName) => {
+        const value = searchParams.get(paramName);
+        if (value) {
+          params.set(paramName, value);
+        }
+      });
+
+      // Reset specified parameters are simply not added to new params
+
       const path = basePath ? `${basePath}?${params.toString()}` : `?${params.toString()}`;
       router.push(path, { scroll: false });
     },
-    [router, searchParams, queryParamName, basePath]
+    [router, searchParams, queryParamName, basePath, preserveParams]
   );
 
   return { currentTab, handleTabChange };


### PR DESCRIPTION
  ### 1. useTab 훅 URL 파라미터 관리 개선
  - **기능 추가**: `preserveParams` 옵션으로 탭 전환 시 원하는 파라미터만
  선택적 보존
  - **문제 해결**: 탭 전환 시 page 파라미터가 유지되어 `/?tab=welcome&page=2`      
  같은 잘못된 URL 생성 방지
  - **동작 변경**:
    - `tag` 파라미터는 유지 (태그 필터링이 탭 간에 의미가 있음)
    - `page` 파라미터는 자동 초기화 (새 탭에서는 첫 페이지부터 시작)

  ### 2. 탭 트리거 스타일 개선
  - **UI 개선**: 탭 버튼에 `cursor: pointer` 스타일 추가하여 클릭 가능함을
  명확히 표시

  ## 🔧 기술적 구현

  ### useTab 훅 인터페이스 확장
  ```typescript
  interface UseTabOptions<T extends string> {
    preserveParams?: string[]; // 탭 전환 시 보존할 파라미터 목록
    // ... 기존 옵션들
  }
```
  
  - Related to #39 #57 