### PR TITLE
 refactor: 권한 체크 로직을 간단한 유틸리티 함수로 개선

### DIFF
--- a/src/app/(content)/posts/[id]/edit/page.tsx
+++ b/src/app/(content)/posts/[id]/edit/page.tsx
@@ -9,6 +9,7 @@
 import { PostForm, usePost, useUpdatePost, type PostFormData } from "@/features/posts";
 // Zustand import 제거됨 - import { useAuth } from "@/store/authStore";
 import { useAuth } from "@/hooks/useAuth";
+import { canEditPost } from "@/lib/auth";
 import { useRouter } from "next/navigation";
 import { use } from "react";
 
@@ -73,6 +74,7 @@ export default function EditPostPage({ params }: EditPostPageProps) {
     );
   }
 
+
   // 게시글 로딩 에러 또는 존재하지 않는 경우
   if (error || !post) {
     return (
@@ -88,9 +90,8 @@ export default function EditPostPage({ params }: EditPostPageProps) {
     );
   }
 
-  const isAuthor = userProfile.nickname === post.writer;
-
-  if (!isAuthor) {
+  // 게시글 수정 권한 체크
+  if (!canEditPost(userProfile, post.writer)) {
     return (
       <div className="mt-32 flex min-h-[400px] flex-col items-center justify-center gap-4">
         <div className="text-lg text-red-600">이 게시글을 수정할 권한이 없습니다.</div>

--- a/src/components/shared/layout/HeaderNavigation.tsx
+++ b/src/components/shared/layout/HeaderNavigation.tsx
@@ -4,16 +4,17 @@ import { Button } from "@/components/ui/button";
 import { useAuth } from "@/hooks/useAuth";
 import { useLoadingDots } from "@/hooks/useLoadingDots";
 import { DropdownActionItem } from "@/types/dropdown";
+import { isAdmin, canCreatePost } from "@/lib/auth";
 import Image from "next/image";
 import Link from "next/link";
-import { usePathname, useRouter } from "next/navigation"; // usePathname import
+import { usePathname, useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import { DropdownMenuList } from "../navigation/DropdownMenuList";
 
 export const HeaderNavigation = () => {
-  const githubLoginUrl = process.env.NEXT_PUBLIC_OAUTH_LOGIN_URL || "/api/auth/github"; // 환경 변수 또는 기본값  // useAuth 훅 호출. React Query가 데이터 관리
+  const githubLoginUrl = process.env.NEXT_PUBLIC_OAUTH_LOGIN_URL || "/api/auth/github";
   const { isLoggedIn, userProfile, isLoading, logout, needsProfileCompletion, refetchAuthStatus } =
-    useAuth(); // refetchAuthStatus 추가
+    useAuth();
 
   console.log("HeaderNavigation state:", {
     isLoggedIn,
@@ -107,8 +108,8 @@ export const HeaderNavigation = () => {
       href: "/mypage",
       isLink: true,
     },
-    // ADMIN 역할일 때만 관리자 페이지 표시
-    ...(userProfile?.role === "ADMIN"
+    // 관리자일 때만 관리자 페이지 표시
+    ...(isAdmin(userProfile)
       ? [
           {
             label: "관리자 페이지",
@@ -190,11 +191,13 @@ export const HeaderNavigation = () => {
         {isLoggedIn && userProfile ? (
           // 로그인된 상태: 프로필 이미지 표시
           <>
-            <Link href="/posts/new" className="hidden md:inline-flex">
-              <Button variant="primary" size="rounded">
-                글쓰기
-              </Button>
-            </Link>
+            {canCreatePost(userProfile) && (
+              <Link href="/posts/new" className="hidden md:inline-flex">
+                <Button variant="primary" size="rounded">
+                  글쓰기
+                </Button>
+              </Link>
+            )}
             <DropdownMenuList triggerElement={headerTriggerElement} items={headerDropdownItems} />
           </>
         ) : (

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,80 +1,53 @@
-import { jwtVerify } from "jose";
-import { cookies } from "next/headers";
-import { logger } from "@/lib/logger";
-
 /**
- * 서버 컴포넌트에서 JWT 토큰을 검증하여 사용자 정보를 가져오는 유틸리티
- */
-
-/**
- * JWT 시크릿 키를 Uint8Array로 변환합니다
- * @param jwtSecret 환경변수에서 가져온 JWT 시크릿 키
- * @returns 변환된 Uint8Array
- */
-function createJWTSecret(jwtSecret: string): Uint8Array {
-  try {
-    // Secret key가 base64로 인코딩되어 있는지 확인하고 처리
-    if (jwtSecret.endsWith("=") || /^[A-Za-z0-9+/]*={0,2}$/.test(jwtSecret)) {
-      // Base64로 디코딩
-      return new Uint8Array(Buffer.from(jwtSecret, "base64"));
-    } else {
-      // 일반 문자열로 처리
-      return new TextEncoder().encode(jwtSecret);
-    }
-  } catch (error) {
-    throw new Error(`Failed to process JWT secret: ${error}`);
-  }
-}
-
-interface UserJWTPayload {
-  sub: string;
-  githubId: string;
-  jti: string;
-  iat: number;
-  exp: number;
-}
-
-/**
- * 서버에서 현재 로그인한 사용자 정보를 가져옵니다
+ * 간단한 권한 체크 유틸리티
  *
- * @returns 사용자 정보 또는 null (로그인하지 않은 경우)
+ * 프로젝트 규모에 적합한 간단한 권한 체크 함수들을 제공합니다.
  */
-export async function getCurrentUser(): Promise<UserJWTPayload | null> {
-  try {
-    const cookieStore = await cookies();
-    const token = cookieStore.get("authorization")?.value;
 
-    if (!token) {
-      return null;
-    }
+import type { UserProfileResponse } from "@/generated/api/models";
 
-    const jwtSecret = process.env.JWT_SECRET_KEY;
-    if (!jwtSecret) {
-      logger.error("JWT_SECRET_KEY is not defined in environment variables");
-      return null;
-    }
-
-    // JWT 토큰을 안전하게 검증
-    const secret = createJWTSecret(jwtSecret);
-
-    const { payload } = await jwtVerify(token, secret, {
-      algorithms: ["HS256"], // 보안을 위해 단일 알고리즘만 허용
-    });
-
-    return payload as unknown as UserJWTPayload;
-  } catch (error) {
-    logger.secureError("JWT authentication failed", error);
-    return null;
-  }
+/**
+ * 사용자가 관리자인지 확인
+ */
+export function isAdmin(userProfile: UserProfileResponse | null | undefined): boolean {
+  return userProfile?.role === "ADMIN";
 }
 
 /**
- * 현재 사용자가 특정 게시글의 작성자인지 확인합니다
- *
- * @param postWriter 게시글 작성자 닉네임
- * @returns 작성자 여부
+ * 사용자가 인증된 상태인지 확인
  */
-export async function isPostAuthor(postWriter: string): Promise<boolean> {
-  const currentUser = await getCurrentUser();
-  return currentUser?.githubId === postWriter;
+export function isAuthenticated(userProfile: UserProfileResponse | null | undefined): boolean {
+  return !!userProfile;
+}
+
+/**
+ * 사용자가 특정 게시글을 수정할 수 있는지 확인
+ * 관리자이거나 게시글 작성자 본인인 경우
+ */
+export function canEditPost(
+  userProfile: UserProfileResponse | null | undefined,
+  postWriter: string
+): boolean {
+  if (!userProfile) return false;
+  return isAdmin(userProfile) || userProfile.nickname === postWriter;
+}
+
+/**
+ * 사용자가 특정 댓글을 수정/삭제할 수 있는지 확인
+ * 관리자이거나 댓글 작성자 본인인 경우
+ */
+export function canManageComment(
+  userProfile: UserProfileResponse | null | undefined,
+  commentAuthor: string
+): boolean {
+  if (!userProfile) return false;
+  return isAdmin(userProfile) || userProfile.nickname === commentAuthor;
+}
+
+/**
+ * 사용자가 게시글을 작성할 수 있는지 확인
+ * 인증된 사용자인 경우 (PRE_REGISTER 제외)
+ */
+export function canCreatePost(userProfile: UserProfileResponse | null | undefined): boolean {
+  return isAuthenticated(userProfile) && userProfile?.role !== "PRE_REGISTER";
 }


### PR DESCRIPTION
- HeaderNavigation: isAdmin, canCreatePost 함수 적용
- 게시글 편집: canEditPost 함수로 권한 체크 개선
- auth.ts: 기존 JWT 검증 로직을 간단한 권한 체크 함수로 교체
- isAdmin, canEditPost, canCreatePost 등 직관적인 함수 제공
- 프로젝트 규모에 적합한 단순한 권한 관리
- Related to #68 