### PR TITLE
refactor: Comment 및 Like Service 서버/클라이언트 분리 (Phase 3)

### DIFF
--- a/src/features/comments/index.ts
+++ b/src/features/comments/index.ts
@@ -3,3 +3,7 @@ export * from "./components";
 export * from "./hooks";
 export * from "./services";
 // export * from "./types";
+
+// Services
+export { commentService } from "./services/commentService";
+export { createCommentServiceServer } from "./services/commentService.server";

--- a/src/features/comments/services/commentService.server.ts
+++ b/src/features/comments/services/commentService.server.ts
@@ -1,0 +1,19 @@
+import { createServerApiClient } from "@/lib/apiClient";
+import { createCommentService } from "./commentService.shared";
+
+/**
+ * 서버 환경에서 사용할 Comment Service 생성
+ *
+ * Next.js Server Components, Server Actions, Route Handlers에서 사용합니다.
+ * 서버 전용 API 클라이언트를 주입하여 환경에 맞는 Service 인스턴스를 반환합니다.
+ *
+ * @returns Comment Service 인스턴스
+ *
+ * @example
+ * // Server Component에서 사용
+ * const commentService = createCommentServiceServer();
+ * const comments = await commentService.getUserComments();
+ */
+export const createCommentServiceServer = () => {
+  return createCommentService(createServerApiClient());
+};

--- a/src/features/comments/services/commentService.shared.ts
+++ b/src/features/comments/services/commentService.shared.ts
@@ -30,21 +30,13 @@ export const createCommentService = (api: DefaultApi) => {
      *
      * @param postId - 게시글 ID
      * @param content - 댓글 내용
-     * @param options - fetch 옵션 (캐싱, revalidate 등)
      * @returns 생성된 댓글 정보
      */
-    async registerComment(
-      postId: number,
-      content: CommentRequest,
-      options?: RequestInit
-    ): Promise<CommentResponse> {
-      const response = await api.addComment(
-        {
-          postId,
-          commentRequest: content,
-        },
-        options
-      );
+    async registerComment(postId: number, content: CommentRequest): Promise<CommentResponse> {
+      const response = await api.addComment({
+        postId,
+        commentRequest: content,
+      });
       return response.data as CommentResponse;
     },
 
@@ -52,10 +44,9 @@ export const createCommentService = (api: DefaultApi) => {
      * 댓글을 삭제합니다.
      *
      * @param commentId - 댓글 ID
-     * @param options - fetch 옵션 (캐싱, revalidate 등)
      */
-    async deleteComment(commentId: number, options?: RequestInit): Promise<void> {
-      await api.deleteComment({ commentId }, options);
+    async deleteComment(commentId: number): Promise<void> {
+      await api.deleteComment({ commentId });
     },
 
     /**

--- a/src/features/comments/services/commentService.shared.ts
+++ b/src/features/comments/services/commentService.shared.ts
@@ -1,0 +1,81 @@
+import type {
+  CommentRequest,
+  CommentResponse,
+  DefaultApi,
+  Pageable,
+  PagedResponseCommentListResponse,
+} from "@/generated/api";
+
+/**
+ * Comment Service 팩토리 함수
+ *
+ * 클라이언트/서버 환경 모두에서 사용 가능한 공통 로직을 제공합니다.
+ * API 클라이언트 인스턴스를 주입받아 환경에 독립적으로 동작합니다.
+ *
+ * @param api - DefaultApi 인스턴스 (클라이언트용 또는 서버용)
+ * @returns Comment Service 객체
+ *
+ * @example
+ * // 클라이언트 환경
+ * const commentService = createCommentService(apiClient);
+ *
+ * @example
+ * // 서버 환경
+ * const commentService = createCommentService(createServerApiClient());
+ */
+export const createCommentService = (api: DefaultApi) => {
+  return {
+    /**
+     * 댓글을 등록합니다.
+     *
+     * @param postId - 게시글 ID
+     * @param content - 댓글 내용
+     * @param options - fetch 옵션 (캐싱, revalidate 등)
+     * @returns 생성된 댓글 정보
+     */
+    async registerComment(
+      postId: number,
+      content: CommentRequest,
+      options?: RequestInit
+    ): Promise<CommentResponse> {
+      const response = await api.addComment(
+        {
+          postId,
+          commentRequest: content,
+        },
+        options
+      );
+      return response.data as CommentResponse;
+    },
+
+    /**
+     * 댓글을 삭제합니다.
+     *
+     * @param commentId - 댓글 ID
+     * @param options - fetch 옵션 (캐싱, revalidate 등)
+     */
+    async deleteComment(commentId: number, options?: RequestInit): Promise<void> {
+      await api.deleteComment({ commentId }, options);
+    },
+
+    /**
+     * 사용자가 작성한 댓글 목록을 조회합니다.
+     *
+     * @param params - 페이지네이션 파라미터
+     * @param options - fetch 옵션 (캐싱, revalidate 등)
+     * @returns 페이지네이션된 댓글 목록
+     */
+    async getUserComments(
+      params?: Pageable,
+      options?: RequestInit
+    ): Promise<PagedResponseCommentListResponse> {
+      const response = await api.getMyComments(params, options);
+      return response.data as PagedResponseCommentListResponse;
+    },
+  };
+};
+
+/**
+ * Comment Service 타입
+ */
+export type CommentService = ReturnType<typeof createCommentService>;

--- a/src/features/comments/services/commentService.ts
+++ b/src/features/comments/services/commentService.ts
@@ -6,6 +6,13 @@ import {
 } from "@/generated/api/models";
 import { apiClient } from "@/lib/apiClient";
 
+/**
+ * 클라이언트 환경에서 사용하는 Comment Service
+ * 브라우저에서 댓글 관련 작업을 수행합니다.
+ *
+ * Note: apiClient를 모듈 레벨에서 import하지만,
+ * 실제 사용은 함수 내부에서만 이루어지므로 순환 참조가 발생하지 않습니다.
+ */
 export const commentService = {
   async registerComment(postId: number, content: CommentRequest): Promise<CommentResponse> {
     const response = await apiClient.addComment({

--- a/src/features/comments/services/commentService.ts
+++ b/src/features/comments/services/commentService.ts
@@ -14,20 +14,51 @@ import { apiClient } from "@/lib/apiClient";
  * 실제 사용은 함수 내부에서만 이루어지므로 순환 참조가 발생하지 않습니다.
  */
 export const commentService = {
-  async registerComment(postId: number, content: CommentRequest): Promise<CommentResponse> {
-    const response = await apiClient.addComment({
-      postId,
-      commentRequest: content,
-    });
+  /**
+   * 댓글을 등록합니다.
+   *
+   * @param postId - 게시글 ID
+   * @param content - 댓글 내용
+   * @param options - fetch 옵션 (캐싱, revalidate 등)
+   * @returns 생성된 댓글 정보
+   */
+  async registerComment(
+    postId: number,
+    content: CommentRequest,
+    options?: RequestInit
+  ): Promise<CommentResponse> {
+    const response = await apiClient.addComment(
+      {
+        postId,
+        commentRequest: content,
+      },
+      options
+    );
     return response.data as CommentResponse;
   },
 
-  async deleteComment(commentId: number): Promise<void> {
-    await apiClient.deleteComment({ commentId });
+  /**
+   * 댓글을 삭제합니다.
+   *
+   * @param commentId - 댓글 ID
+   * @param options - fetch 옵션 (캐싱, revalidate 등)
+   */
+  async deleteComment(commentId: number, options?: RequestInit): Promise<void> {
+    await apiClient.deleteComment({ commentId }, options);
   },
 
-  async getUserComments(params?: Pageable): Promise<PagedResponseCommentListResponse> {
-    const response = await apiClient.getMyComments(params);
+  /**
+   * 사용자가 작성한 댓글 목록을 조회합니다.
+   *
+   * @param params - 페이지네이션 파라미터
+   * @param options - fetch 옵션 (캐싱, revalidate 등)
+   * @returns 페이지네이션된 댓글 목록
+   */
+  async getUserComments(
+    params?: Pageable,
+    options?: RequestInit
+  ): Promise<PagedResponseCommentListResponse> {
+    const response = await apiClient.getMyComments(params, options);
     return response.data as PagedResponseCommentListResponse;
   },
 };

--- a/src/features/comments/services/commentService.ts
+++ b/src/features/comments/services/commentService.ts
@@ -19,21 +19,13 @@ export const commentService = {
    *
    * @param postId - 게시글 ID
    * @param content - 댓글 내용
-   * @param options - fetch 옵션 (캐싱, revalidate 등)
    * @returns 생성된 댓글 정보
    */
-  async registerComment(
-    postId: number,
-    content: CommentRequest,
-    options?: RequestInit
-  ): Promise<CommentResponse> {
-    const response = await apiClient.addComment(
-      {
-        postId,
-        commentRequest: content,
-      },
-      options
-    );
+  async registerComment(postId: number, content: CommentRequest): Promise<CommentResponse> {
+    const response = await apiClient.addComment({
+      postId,
+      commentRequest: content,
+    });
     return response.data as CommentResponse;
   },
 
@@ -41,10 +33,9 @@ export const commentService = {
    * 댓글을 삭제합니다.
    *
    * @param commentId - 댓글 ID
-   * @param options - fetch 옵션 (캐싱, revalidate 등)
    */
-  async deleteComment(commentId: number, options?: RequestInit): Promise<void> {
-    await apiClient.deleteComment({ commentId }, options);
+  async deleteComment(commentId: number): Promise<void> {
+    await apiClient.deleteComment({ commentId });
   },
 
   /**

--- a/src/features/posts/index.ts
+++ b/src/features/posts/index.ts
@@ -51,6 +51,8 @@ export {
 export { postService } from "./services/postService";
 export { createPostServiceServer } from "./services/postService.server";
 export type { LikedPostResponse } from "./services/postService";
+export { likeService } from "./services/likeService";
+export { createLikeServiceServer } from "./services/likeService.server";
 
 // Types
 export type {

--- a/src/features/posts/services/likeService.server.ts
+++ b/src/features/posts/services/likeService.server.ts
@@ -1,0 +1,19 @@
+import { createServerApiClient } from "@/lib/apiClient";
+import { createLikeService } from "./likeService.shared";
+
+/**
+ * 서버 환경에서 사용할 Like Service 생성
+ *
+ * Next.js Server Components, Server Actions, Route Handlers에서 사용합니다.
+ * 서버 전용 API 클라이언트를 주입하여 환경에 맞는 Service 인스턴스를 반환합니다.
+ *
+ * @returns Like Service 인스턴스
+ *
+ * @example
+ * // Server Component에서 사용
+ * const likeService = createLikeServiceServer();
+ * const isLiked = await likeService.checkLikeStatus(postId);
+ */
+export const createLikeServiceServer = () => {
+  return createLikeService(createServerApiClient());
+};

--- a/src/features/posts/services/likeService.shared.ts
+++ b/src/features/posts/services/likeService.shared.ts
@@ -23,20 +23,18 @@ export const createLikeService = (api: DefaultApi) => {
      * 게시글에 좋아요를 추가합니다.
      *
      * @param postId - 게시글 ID
-     * @param options - fetch 옵션 (캐싱, revalidate 등)
      */
-    async addLike(postId: number, options?: RequestInit): Promise<void> {
-      await api.likePost({ postId }, options);
+    async addLike(postId: number): Promise<void> {
+      await api.likePost({ postId });
     },
 
     /**
      * 게시글의 좋아요를 취소합니다.
      *
      * @param postId - 게시글 ID
-     * @param options - fetch 옵션 (캐싱, revalidate 등)
      */
-    async removeLike(postId: number, options?: RequestInit): Promise<void> {
-      await api.unlikePost({ postId }, options);
+    async removeLike(postId: number): Promise<void> {
+      await api.unlikePost({ postId });
     },
 
     /**

--- a/src/features/posts/services/likeService.shared.ts
+++ b/src/features/posts/services/likeService.shared.ts
@@ -1,0 +1,59 @@
+import type { DefaultApi } from "@/generated/api";
+
+/**
+ * Like Service 팩토리 함수
+ *
+ * 클라이언트/서버 환경 모두에서 사용 가능한 공통 로직을 제공합니다.
+ * API 클라이언트 인스턴스를 주입받아 환경에 독립적으로 동작합니다.
+ *
+ * @param api - DefaultApi 인스턴스 (클라이언트용 또는 서버용)
+ * @returns Like Service 객체
+ *
+ * @example
+ * // 클라이언트 환경
+ * const likeService = createLikeService(apiClient);
+ *
+ * @example
+ * // 서버 환경
+ * const likeService = createLikeService(createServerApiClient());
+ */
+export const createLikeService = (api: DefaultApi) => {
+  return {
+    /**
+     * 게시글에 좋아요를 추가합니다.
+     *
+     * @param postId - 게시글 ID
+     * @param options - fetch 옵션 (캐싱, revalidate 등)
+     */
+    async addLike(postId: number, options?: RequestInit): Promise<void> {
+      await api.likePost({ postId }, options);
+    },
+
+    /**
+     * 게시글의 좋아요를 취소합니다.
+     *
+     * @param postId - 게시글 ID
+     * @param options - fetch 옵션 (캐싱, revalidate 등)
+     */
+    async removeLike(postId: number, options?: RequestInit): Promise<void> {
+      await api.unlikePost({ postId }, options);
+    },
+
+    /**
+     * 사용자가 특정 게시글에 좋아요를 눌렀는지 확인합니다.
+     *
+     * @param postId - 게시글 ID
+     * @param options - fetch 옵션 (캐싱, revalidate 등)
+     * @returns 좋아요 상태 (true: 좋아요 누름, false: 좋아요 안누름)
+     */
+    async checkLikeStatus(postId: number, options?: RequestInit): Promise<boolean> {
+      const response = await api.isPostLiked({ postId }, options);
+      return response.data as boolean;
+    },
+  };
+};
+
+/**
+ * Like Service 타입
+ */
+export type LikeService = ReturnType<typeof createLikeService>;

--- a/src/features/posts/services/likeService.ts
+++ b/src/features/posts/services/likeService.ts
@@ -1,5 +1,12 @@
 import { apiClient } from "@/lib/apiClient";
 
+/**
+ * 클라이언트 환경에서 사용하는 Like Service
+ * 브라우저에서 좋아요 관련 작업을 수행합니다.
+ *
+ * Note: apiClient를 모듈 레벨에서 import하지만,
+ * 실제 사용은 함수 내부에서만 이루어지므로 순환 참조가 발생하지 않습니다.
+ */
 export const likeService = {
   /**
    * 게시글에 좋아요를 추가합니다.

--- a/src/features/posts/services/likeService.ts
+++ b/src/features/posts/services/likeService.ts
@@ -10,27 +10,33 @@ import { apiClient } from "@/lib/apiClient";
 export const likeService = {
   /**
    * 게시글에 좋아요를 추가합니다.
+   *
    * @param postId - 게시글 ID
+   * @param options - fetch 옵션 (캐싱, revalidate 등)
    */
-  async addLike(postId: number): Promise<void> {
-    await apiClient.likePost({ postId });
+  async addLike(postId: number, options?: RequestInit): Promise<void> {
+    await apiClient.likePost({ postId }, options);
   },
 
   /**
    * 게시글의 좋아요를 취소합니다.
+   *
    * @param postId - 게시글 ID
+   * @param options - fetch 옵션 (캐싱, revalidate 등)
    */
-  async removeLike(postId: number): Promise<void> {
-    await apiClient.unlikePost({ postId });
+  async removeLike(postId: number, options?: RequestInit): Promise<void> {
+    await apiClient.unlikePost({ postId }, options);
   },
 
   /**
    * 사용자가 특정 게시글에 좋아요를 눌렀는지 확인합니다.
+   *
    * @param postId - 게시글 ID
+   * @param options - fetch 옵션 (캐싱, revalidate 등)
    * @returns 좋아요 상태 (true: 좋아요 누름, false: 좋아요 안누름)
    */
-  async checkLikeStatus(postId: number): Promise<boolean> {
-    const response = await apiClient.isPostLiked({ postId });
+  async checkLikeStatus(postId: number, options?: RequestInit): Promise<boolean> {
+    const response = await apiClient.isPostLiked({ postId }, options);
     return response.data as boolean;
   },
 } as const;

--- a/src/features/posts/services/likeService.ts
+++ b/src/features/posts/services/likeService.ts
@@ -12,20 +12,18 @@ export const likeService = {
    * 게시글에 좋아요를 추가합니다.
    *
    * @param postId - 게시글 ID
-   * @param options - fetch 옵션 (캐싱, revalidate 등)
    */
-  async addLike(postId: number, options?: RequestInit): Promise<void> {
-    await apiClient.likePost({ postId }, options);
+  async addLike(postId: number): Promise<void> {
+    await apiClient.likePost({ postId });
   },
 
   /**
    * 게시글의 좋아요를 취소합니다.
    *
    * @param postId - 게시글 ID
-   * @param options - fetch 옵션 (캐싱, revalidate 등)
    */
-  async removeLike(postId: number, options?: RequestInit): Promise<void> {
-    await apiClient.unlikePost({ postId }, options);
+  async removeLike(postId: number): Promise<void> {
+    await apiClient.unlikePost({ postId });
   },
 
   /**

--- a/src/generated/api/apis/index.ts
+++ b/src/generated/api/apis/index.ts
@@ -1,3 +1,3 @@
 /* tslint:disable */
-/* eslint-disable */
+ 
 export * from './DefaultApi';

--- a/src/generated/api/index.ts
+++ b/src/generated/api/index.ts
@@ -1,5 +1,5 @@
 /* tslint:disable */
-/* eslint-disable */
+ 
 export * from './runtime';
 export * from './apis/index';
 export * from './models/index';

--- a/src/generated/api/models/index.ts
+++ b/src/generated/api/models/index.ts
@@ -1,5 +1,5 @@
 /* tslint:disable */
-/* eslint-disable */
+ 
 export * from './AccessTokenResponse';
 export * from './AdmissionResultResponse';
 export * from './ChatMessageRequest';


### PR DESCRIPTION
## Summary
Comment Service와 Like Service를 서버/클라이언트 환경에서 사용할 수 있도록 분리했습니다.

## Changes
- **Comment Service 분리**
  - `commentService.shared.ts`: 공유 로직 추출 (팩토리 패턴)
  - `commentService.server.ts`: 서버용 팩토리 함수
  - `commentService.ts`: 클라이언트용 (순환 참조 방지를 위해 기존 패턴 유지)

- **Like Service 분리**
  - `likeService.shared.ts`: 공유 로직 추출 (팩토리 패턴)
  - `likeService.server.ts`: 서버용 팩토리 함수
  - `likeService.ts`: 클라이언트용 (순환 참조 방지를 위해 기존 패턴 유지)

- **Export 추가**
  - `features/comments/index.ts`: `createCommentServiceServer` export 추가
  - `features/posts/index.ts`: `createLikeServiceServer` export 추가

## Architecture
```
Service Layer Pattern:
- .shared.ts: createService(api: DefaultApi) 팩토리 함수
- .server.ts: createServiceServer() → createService(createServerApiClient())
- .ts: apiClient를 함수 내부에서 사용 (순환 참조 방지)
```

## Test Plan
- [x] 빌드 테스트 통과 (`yarn build`)
- [x] 타입 체크 통과
- [x] 순환 참조 문제 해결 확인

## Related
- Issue: #96
- Phase 1: Post Service 분리 (#100)
- Phase 2: User Service 분리 (#102)