### PR TITLE
refactor: 서버 컴포넌트에서 Service 레이어 사용

### DIFF
--- a/src/app/(content)/posts/[id]/page.tsx
+++ b/src/app/(content)/posts/[id]/page.tsx
@@ -3,7 +3,7 @@ import {
   DynamicPostCommentsSection,
 } from "@/components/dynamic/DynamicComponents";
 import { createPostServiceServer, PostHeader, PostStats } from "@/features/posts";
-import { createServerApiClient } from "@/lib/apiClient";
+import { createUserServiceServer } from "@/features/user";
 import { canEditPost } from "@/lib/auth";
 import { Metadata } from "next";
 import { notFound } from "next/navigation";
@@ -129,14 +129,11 @@ export default async function PostPage({ params }: { params: Promise<{ id: strin
     // 현재 로그인한 사용자가 게시글을 수정할 수 있는지 확인
     let isCurrentUserAuthor = false;
     try {
-      const serverApiClient = createServerApiClient();
-      const userProfile = await serverApiClient.getCurrentUserProfile();
-      const profileData = userProfile?.data;
+      const userService = createUserServiceServer();
+      const profileData = await userService.getProfile();
 
       if (profileData) {
         isCurrentUserAuthor = canEditPost(profileData, post.writer || "");
-      } else {
-        isCurrentUserAuthor = false;
       }
     } catch (error) {
       // 로그인되지 않은 사용자나 API 에러의 경우 false로 처리

--- a/src/app/(dashboard)/mypage/page.tsx
+++ b/src/app/(dashboard)/mypage/page.tsx
@@ -9,15 +9,15 @@
  */
 
 import { ProfileLayout } from "@/components/shared";
-import { createServerApiClient } from "@/lib/apiClient";
+import { createUserServiceServer } from "@/features/user";
 
 export default async function MyPage() {
   console.log("Rendering MyPage Server Component");
 
-  // 인증 상태 확인 - 서버 API 클라이언트 사용
+  // 인증 상태 확인 - User Service 사용
   try {
-    const api = createServerApiClient();
-    await api.getCurrentUserProfile();
+    const userService = createUserServiceServer();
+    await userService.getProfile();
   } catch (error) {
     console.error("Authentication failed:", error);
   }


### PR DESCRIPTION
## Summary
서버 컴포넌트에서 `createServerApiClient()` 직접 호출을 제거하고 Service 레이어를 사용하도록 마이그레이션했습니다.

## Changes

### 게시글 상세 페이지 (`posts/[id]/page.tsx`)
**Before:**
```typescript
const serverApiClient = createServerApiClient();
const userProfile = await serverApiClient.getCurrentUserProfile();
const profileData = userProfile?.data;
```

**After:**
```typescript
const userService = createUserServiceServer();
const profileData = await userService.getProfile();
```

### 마이페이지 (`mypage/page.tsx`)
**Before:**
```typescript
const api = createServerApiClient();
await api.getCurrentUserProfile();
```

**After:**
```typescript
const userService = createUserServiceServer();
await userService.getProfile();
```

## Benefits
- ✅ **일관성**: 모든 서버 컴포넌트가 Service 레이어를 통해 API 호출
- ✅ **추상화**: API 클라이언트 직접 호출 제거로 유지보수성 향상
- ✅ **타입 안정성**: Service 메서드 시그니처를 통한 타입 체크
- ✅ **테스트 용이성**: Service 레이어 Mock 가능

## Test Plan
- [x] 빌드 테스트 통과 (`yarn build`)
- [x] 타입 체크 통과
- [x] 게시글 상세 페이지 정상 렌더링
- [x] 작성자 수정 권한 확인 로직 정상 작동
- [x] 마이페이지 인증 확인 로직 정상 작동

## Related
- Issue: #96
- Phase 1: Post Service 분리 (#100)
- Phase 2: User Service 분리 (#102)
- Phase 3: Comment & Like Service 분리 (#103)