### PR TITLE
[fix] 전역 챗봇 hydration mismatch 오류 수정

### DIFF
--- a/src/features/chatbot/components/MessageList.tsx
+++ b/src/features/chatbot/components/MessageList.tsx
@@ -1,16 +1,20 @@
 "use client";
 
-import { forwardRef } from "react";
+import { forwardRef, useEffect, useState } from "react";
 import { MessageListProps } from "../types";
 import { BotMessage, UserMessage } from "./messages";
 
 const MessageList = forwardRef<HTMLDivElement, MessageListProps>(({ messages, isPending }, ref) => {
+  const [currentTime, setCurrentTime] = useState("");
+
+  useEffect(() => {
+    setCurrentTime(new Date().toLocaleTimeString("ko-KR", { hour: "2-digit", minute: "2-digit" }));
+  }, []);
+
   return (
     <div className="flex-1 overflow-y-auto p-4">
       <div className="mb-4">
-        <div className="mb-4 text-center text-sm text-gray-500">
-          {new Date().toLocaleTimeString("ko-KR", { hour: "2-digit", minute: "2-digit" })}
-        </div>
+        <div className="mb-4 text-center text-sm text-gray-500">{currentTime}</div>
 
         {messages.map((message) => (
           <div key={message.id}>


### PR DESCRIPTION
## 개요
전역 레이아웃에 포함된 챗봇에서 초기 렌더 시 현재 시각을 바로 출력하던 경로를 안정화해 hydration mismatch 발생 가능성을 줄인다.

## 변경 사항
- 챗봇 메시지 목록의 초기 렌더에서 현재 시각을 직접 출력하지 않도록 변경
- hydration 이후에만 시간 문자열이 채워지도록 조정

## 테스트
- [x] 빌드 성공 확인 (`rm -rf .next && yarn build`)
- [x] 주요 기능 동작 확인
- [x] 테스트 통과 확인 (`jest --ci --passWithNoTests` via push hook)

Closes #147