### PR TITLE
[fix] 로그인 유지 false logout 완화

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ certificates
 
 
 claudedocs
+.omx/

--- a/src/__tests__/proxy.test.ts
+++ b/src/__tests__/proxy.test.ts
@@ -155,7 +155,7 @@ describe("proxy", () => {
         headers: { getSetCookie: () => ["authorization=new_token; HttpOnly; Path=/"] },
       } as unknown as Response);
 
-      const req = makeRequest("/", { token: nearExpiryToken() });
+      const req = makeRequest("/", { token: nearExpiryToken(), refreshToken: "refresh-token" });
       const res = await proxy(req);
 
       expect(res.headers.get("cache-control")).toContain("no-store");
@@ -165,7 +165,7 @@ describe("proxy", () => {
     it("재발급 API가 실패해도 요청은 그대로 통과해야 함", async () => {
       jest.spyOn(global, "fetch").mockResolvedValue(new Response(null, { status: 401 }));
 
-      const req = makeRequest("/", { token: nearExpiryToken() });
+      const req = makeRequest("/", { token: nearExpiryToken(), refreshToken: "refresh-token" });
       const res = await proxy(req);
 
       expect(res.status).not.toBe(401);
@@ -174,7 +174,7 @@ describe("proxy", () => {
     it("재발급 API 네트워크 오류 시 요청은 그대로 통과해야 함", async () => {
       jest.spyOn(global, "fetch").mockRejectedValue(new Error("network error"));
 
-      const req = makeRequest("/", { token: nearExpiryToken() });
+      const req = makeRequest("/", { token: nearExpiryToken(), refreshToken: "refresh-token" });
       // 예외 없이 정상 처리되어야 함
       await expect(proxy(req)).resolves.toBeDefined();
     });
@@ -210,6 +210,24 @@ describe("proxy", () => {
       expect(headers.get("cookie")).toContain("refreshToken=refresh-token");
       expect(headers.get("authorization")).toBe("Bearer new_token");
     });
+
+    it("기존 Authorization 헤더가 있으면 재발급 후에도 유지해야 함", () => {
+      const oldToken = nearExpiryToken();
+      const req = new NextRequest("http://localhost/", {
+        headers: {
+          "user-agent": "Mozilla/5.0",
+          cookie: `authorization=${oldToken}; refreshToken=refresh-token`,
+          authorization: "Bearer caller-token",
+        },
+      });
+
+      const headers = buildForwardedRequestHeaders(req, [
+        "authorization=new_token; HttpOnly; Path=/",
+      ]);
+
+      expect(headers.get("cookie")).toContain("authorization=new_token");
+      expect(headers.get("authorization")).toBe("Bearer caller-token");
+    });
   });
 
   // ── CDN 캐시 헤더 ───────────────────────────────────────────
@@ -243,6 +261,7 @@ describe("proxy", () => {
       const res = await proxy(req);
 
       expect(res.headers.get("cache-control")).toContain("private");
+      expect(res.headers.get("cache-control")).not.toContain("no-store");
       expect(res.headers.get("cache-control")).not.toContain("public");
     });
   });

--- a/src/__tests__/proxy.test.ts
+++ b/src/__tests__/proxy.test.ts
@@ -1,5 +1,5 @@
 import { NextRequest } from "next/server";
-import { proxy } from "@/proxy";
+import { buildForwardedRequestHeaders, proxy } from "@/proxy";
 
 // --- 헬퍼 ---
 
@@ -22,12 +22,20 @@ function validToken() {
   return makeJwt(Math.floor(Date.now() / 1000) + 600);
 }
 
-function makeRequest(path: string, options: { ua?: string; token?: string } = {}): NextRequest {
+function makeRequest(
+  path: string,
+  options: { ua?: string; token?: string; refreshToken?: string } = {}
+): NextRequest {
   const headers: Record<string, string> = {
     "user-agent": options.ua ?? "Mozilla/5.0",
   };
-  if (options.token) {
-    headers["cookie"] = `authorization=${options.token}`;
+  const cookies = [
+    options.token ? `authorization=${options.token}` : null,
+    options.refreshToken ? `refreshToken=${options.refreshToken}` : null,
+  ].filter(Boolean);
+
+  if (cookies.length > 0) {
+    headers["cookie"] = cookies.join("; ");
   }
   return new NextRequest(`http://localhost${path}`, { headers });
 }
@@ -87,7 +95,7 @@ describe("proxy", () => {
     });
 
     it("만료 임박 토큰은 재발급을 시도해야 함", async () => {
-      const req = makeRequest("/", { token: nearExpiryToken() });
+      const req = makeRequest("/", { token: nearExpiryToken(), refreshToken: "refresh-token" });
       await proxy(req);
       expect(global.fetch).toHaveBeenCalledWith(
         expect.stringContaining("/api/auth/reissue"),
@@ -105,6 +113,15 @@ describe("proxy", () => {
   // ── 토큰 재발급 흐름 ────────────────────────────────────────
 
   describe("토큰 재발급", () => {
+    it("authorization 쿠키가 없어도 refreshToken 쿠키가 있으면 재발급을 시도해야 함", async () => {
+      const req = makeRequest("/", { refreshToken: "refresh-token" });
+      await proxy(req);
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.stringContaining("/api/auth/reissue"),
+        expect.objectContaining({ method: "POST" })
+      );
+    });
+
     it("토큰이 없으면 재발급 시도 없이 통과해야 함", async () => {
       const req = makeRequest("/");
       await proxy(req);
@@ -126,7 +143,7 @@ describe("proxy", () => {
         headers: { getSetCookie: () => [setCookieValue] },
       } as unknown as Response);
 
-      const req = makeRequest("/", { token: nearExpiryToken() });
+      const req = makeRequest("/", { token: nearExpiryToken(), refreshToken: "refresh-token" });
       const res = await proxy(req);
 
       expect(res.headers.get("set-cookie")).toContain("authorization=new_token");
@@ -166,7 +183,7 @@ describe("proxy", () => {
       const token = nearExpiryToken();
       jest.spyOn(global, "fetch").mockResolvedValue(new Response(null, { status: 401 }));
 
-      const req = makeRequest("/", { token });
+      const req = makeRequest("/", { token, refreshToken: "refresh-token" });
       await proxy(req);
 
       const [, init] = (global.fetch as jest.Mock).mock.calls[0];
@@ -174,6 +191,24 @@ describe("proxy", () => {
       expect((init.headers as Record<string, string>)["cookie"]).toContain(
         `authorization=${token}`
       );
+      expect((init.headers as Record<string, string>)["cookie"]).toContain(
+        "refreshToken=refresh-token"
+      );
+    });
+  });
+
+  describe("same-request auth propagation", () => {
+    it("재발급된 authorization 쿠키를 같은 요청의 forwarded header에도 반영해야 함", () => {
+      const oldToken = nearExpiryToken();
+      const req = makeRequest("/", { token: oldToken, refreshToken: "refresh-token" });
+
+      const headers = buildForwardedRequestHeaders(req, [
+        "authorization=new_token; HttpOnly; Path=/",
+      ]);
+
+      expect(headers.get("cookie")).toContain("authorization=new_token");
+      expect(headers.get("cookie")).toContain("refreshToken=refresh-token");
+      expect(headers.get("authorization")).toBe("Bearer new_token");
     });
   });
 
@@ -201,6 +236,14 @@ describe("proxy", () => {
       const req = makeRequest("/api/posts");
       const res = await proxy(req);
       expect(res.headers.get("cache-control")).toBeNull();
+    });
+
+    it("authorization 쿠키가 있는 공개 페이지는 public 캐시를 사용하지 않아야 함", async () => {
+      const req = makeRequest("/", { token: validToken(), refreshToken: "refresh-token" });
+      const res = await proxy(req);
+
+      expect(res.headers.get("cache-control")).toContain("private");
+      expect(res.headers.get("cache-control")).not.toContain("public");
     });
   });
 });

--- a/src/__tests__/proxy.test.ts
+++ b/src/__tests__/proxy.test.ts
@@ -108,6 +108,15 @@ describe("proxy", () => {
       await proxy(req);
       expect(global.fetch).not.toHaveBeenCalled();
     });
+
+    it("JWT 형식이 아닌 access token이어도 refreshToken이 있으면 재발급을 시도해야 함", async () => {
+      const req = makeRequest("/", { token: "not-a-jwt", refreshToken: "refresh-token" });
+      await proxy(req);
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.stringContaining("/api/auth/reissue"),
+        expect.objectContaining({ method: "POST" })
+      );
+    });
   });
 
   // ── 토큰 재발급 흐름 ────────────────────────────────────────
@@ -232,18 +241,7 @@ describe("proxy", () => {
 
   // ── CDN 캐시 헤더 ───────────────────────────────────────────
 
-  describe("CDN 캐시 헤더", () => {
-    it.each([
-      ["/", "홈"],
-      ["/posts/my-post-slug", "게시글 상세"],
-      ["/search", "검색"],
-      ["/profile/username", "프로필"],
-    ])("%s (%s)는 public 캐시 헤더를 설정해야 함", async (path) => {
-      const req = makeRequest(path);
-      const res = await proxy(req);
-      expect(res.headers.get("cache-control")).toContain("s-maxage=3600");
-    });
-
+  describe("페이지 캐시 헤더", () => {
     it("/dashboard는 캐시 헤더를 설정하지 않아야 함", async () => {
       const req = makeRequest("/dashboard");
       const res = await proxy(req);
@@ -256,13 +254,22 @@ describe("proxy", () => {
       expect(res.headers.get("cache-control")).toBeNull();
     });
 
-    it("authorization 쿠키가 있는 공개 페이지는 public 캐시를 사용하지 않아야 함", async () => {
+    it.each([
+      ["/", "홈"],
+      ["/posts/my-post-slug", "게시글 상세"],
+      ["/search", "검색"],
+      ["/profile/username", "프로필"],
+    ])("%s (%s)는 middleware 단계에서 public 캐시 헤더를 설정하지 않아야 함", async (path) => {
+      const req = makeRequest(path);
+      const res = await proxy(req);
+      expect(res.headers.get("cache-control")).toBeNull();
+    });
+
+    it("authorization 쿠키가 있는 공개 페이지도 middleware 단계에서 캐시 헤더를 강제하지 않아야 함", async () => {
       const req = makeRequest("/", { token: validToken(), refreshToken: "refresh-token" });
       const res = await proxy(req);
 
-      expect(res.headers.get("cache-control")).toContain("private");
-      expect(res.headers.get("cache-control")).not.toContain("no-store");
-      expect(res.headers.get("cache-control")).not.toContain("public");
+      expect(res.headers.get("cache-control")).toBeNull();
     });
   });
 });

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -149,10 +149,12 @@ export function buildForwardedRequestHeaders(request: NextRequest, setCookies: s
   }
 
   const refreshedAccessToken = requestCookies.get("authorization");
-  if (refreshedAccessToken) {
-    forwardedHeaders.set("authorization", `Bearer ${refreshedAccessToken}`);
-  } else {
-    forwardedHeaders.delete("authorization");
+  if (!request.headers.has("authorization")) {
+    if (refreshedAccessToken) {
+      forwardedHeaders.set("authorization", `Bearer ${refreshedAccessToken}`);
+    } else {
+      forwardedHeaders.delete("authorization");
+    }
   }
 
   return forwardedHeaders;
@@ -173,7 +175,7 @@ function applyCacheHeaders(
   hasAuthSession: boolean
 ): void {
   if (hasAuthSession) {
-    response.headers.set("Cache-Control", "private, no-store, no-cache, must-revalidate");
+    response.headers.set("Cache-Control", "private, max-age=0, must-revalidate");
     return;
   }
 

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -81,10 +81,102 @@ async function reissueToken(request: NextRequest): Promise<string[] | null> {
   }
 }
 
+type SetCookieMutation = {
+  name: string;
+  value: string;
+  shouldDelete: boolean;
+};
+
+function parseSetCookieMutation(setCookie: string): SetCookieMutation | null {
+  const [nameValue, ...attributes] = setCookie.split(";");
+  const separatorIndex = nameValue.indexOf("=");
+
+  if (separatorIndex === -1) return null;
+
+  const name = nameValue.slice(0, separatorIndex).trim();
+  const value = nameValue.slice(separatorIndex + 1).trim();
+
+  if (!name) return null;
+
+  const normalizedAttributes = attributes.map((attribute) => attribute.trim());
+  const maxAgeAttribute = normalizedAttributes.find((attribute) =>
+    attribute.toLowerCase().startsWith("max-age=")
+  );
+  const expiresAttribute = normalizedAttributes.find((attribute) =>
+    attribute.toLowerCase().startsWith("expires=")
+  );
+  const maxAge = maxAgeAttribute
+    ? Number.parseInt(maxAgeAttribute.slice("max-age=".length), 10)
+    : null;
+  const expiresAt = expiresAttribute
+    ? Date.parse(expiresAttribute.slice("expires=".length))
+    : Number.NaN;
+  const shouldDelete =
+    value === "" ||
+    (maxAge !== null && Number.isFinite(maxAge) && maxAge <= 0) ||
+    (!Number.isNaN(expiresAt) && expiresAt <= Date.now());
+
+  return { name, value, shouldDelete };
+}
+
+export function buildForwardedRequestHeaders(request: NextRequest, setCookies: string[]): Headers {
+  const forwardedHeaders = new Headers(request.headers);
+  const requestCookies = new Map(
+    request.cookies.getAll().map((cookie) => [cookie.name, cookie.value])
+  );
+
+  for (const setCookie of setCookies) {
+    const mutation = parseSetCookieMutation(setCookie);
+    if (!mutation) continue;
+
+    if (mutation.shouldDelete) {
+      requestCookies.delete(mutation.name);
+      continue;
+    }
+
+    requestCookies.set(mutation.name, mutation.value);
+  }
+
+  if (requestCookies.size > 0) {
+    forwardedHeaders.set(
+      "cookie",
+      Array.from(requestCookies.entries())
+        .map(([name, value]) => `${name}=${value}`)
+        .join("; ")
+    );
+  } else {
+    forwardedHeaders.delete("cookie");
+  }
+
+  const refreshedAccessToken = requestCookies.get("authorization");
+  if (refreshedAccessToken) {
+    forwardedHeaders.set("authorization", `Bearer ${refreshedAccessToken}`);
+  } else {
+    forwardedHeaders.delete("authorization");
+  }
+
+  return forwardedHeaders;
+}
+
+function hasAuthSessionCookie(request: NextRequest): boolean {
+  return Boolean(
+    request.cookies.get("authorization")?.value || request.cookies.get("refreshToken")?.value
+  );
+}
+
 /**
  * 공개 페이지에 Vercel Edge Cache 헤더를 적용합니다.
  */
-function applyCacheHeaders(response: NextResponse, pathname: string): void {
+function applyCacheHeaders(
+  response: NextResponse,
+  pathname: string,
+  hasAuthSession: boolean
+): void {
+  if (hasAuthSession) {
+    response.headers.set("Cache-Control", "private, no-store, no-cache, must-revalidate");
+    return;
+  }
+
   const isCacheable = CACHEABLE_PATHS.some((pattern) => pattern.test(pathname));
 
   if (isCacheable) {
@@ -106,28 +198,37 @@ export async function proxy(request: NextRequest) {
 
   // 2. 토큰 선제적 재발급 (만료 60초 전 ~ 만료 후)
   const accessToken = request.cookies.get("authorization")?.value;
+  const refreshToken = request.cookies.get("refreshToken")?.value;
 
-  if (accessToken) {
+  const shouldAttemptReissue = (() => {
+    if (!refreshToken) return false;
+    if (!accessToken) return true;
+
     const exp = decodeJwtExp(accessToken);
     const nowSeconds = Math.floor(Date.now() / 1000);
+    return exp !== null && exp - nowSeconds < TOKEN_REFRESH_BUFFER_SECONDS;
+  })();
 
-    if (exp !== null && exp - nowSeconds < TOKEN_REFRESH_BUFFER_SECONDS) {
-      const newSetCookies = await reissueToken(request);
+  if (shouldAttemptReissue) {
+    const newSetCookies = await reissueToken(request);
 
-      if (newSetCookies) {
-        // 재발급 성공: 새 쿠키를 응답에 포함하여 클라이언트에 전달
-        // 현재 요청은 구 토큰으로 처리되지만 구 토큰은 아직 유효함
-        // 다음 요청부터 새 토큰 사용
-        const response = NextResponse.next();
-        // Set-Cookie가 포함된 응답은 CDN에 캐시되면 안 됨 (타 사용자에게 쿠키 전달 위험)
-        response.headers.set("Cache-Control", "private, no-store, no-cache, must-revalidate");
-        for (const cookie of newSetCookies) {
-          response.headers.append("Set-Cookie", cookie);
-        }
-        return response;
+    if (newSetCookies) {
+      const forwardedHeaders = buildForwardedRequestHeaders(request, newSetCookies);
+      // 재발급 성공: 새 쿠키를 응답에 포함하고 현재 요청에도 반영하여
+      // 같은 요청 내 Server Component / Route Handler와 auth 상태를 일치시킴
+      const response = NextResponse.next({
+        request: {
+          headers: forwardedHeaders,
+        },
+      });
+      // Set-Cookie가 포함된 응답은 CDN에 캐시되면 안 됨 (타 사용자에게 쿠키 전달 위험)
+      response.headers.set("Cache-Control", "private, no-store, no-cache, must-revalidate");
+      for (const cookie of newSetCookies) {
+        response.headers.append("Set-Cookie", cookie);
       }
-      // 재발급 실패: 그대로 진행 → 하위 레이어(Server Action, RSC)에서 401 처리
+      return response;
     }
+    // 재발급 실패: 그대로 진행 → 하위 레이어(Server Action, RSC)에서 401 처리
   }
 
   // 3. API 경로는 캐시 없이 통과
@@ -137,7 +238,7 @@ export async function proxy(request: NextRequest) {
 
   // 4. 페이지 응답에 CDN 캐시 헤더 적용
   const response = NextResponse.next();
-  applyCacheHeaders(response, pathname);
+  applyCacheHeaders(response, pathname, hasAuthSessionCookie(request));
   return response;
 }
 

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -19,9 +19,6 @@ const BLOCKED_BOT_PATTERNS = [
   /cohere-ai/i,
 ];
 
-// 캐시를 적용할 공개 페이지 경로
-const CACHEABLE_PATHS = [/^\/$/, /^\/posts\/[^/]+$/, /^\/search/, /^\/profile\/[^/]+$/];
-
 // 만료 n초 전부터 선제적으로 재발급
 const TOKEN_REFRESH_BUFFER_SECONDS = 60;
 
@@ -160,34 +157,6 @@ export function buildForwardedRequestHeaders(request: NextRequest, setCookies: s
   return forwardedHeaders;
 }
 
-function hasAuthSessionCookie(request: NextRequest): boolean {
-  return Boolean(
-    request.cookies.get("authorization")?.value || request.cookies.get("refreshToken")?.value
-  );
-}
-
-/**
- * 공개 페이지에 Vercel Edge Cache 헤더를 적용합니다.
- */
-function applyCacheHeaders(
-  response: NextResponse,
-  pathname: string,
-  hasAuthSession: boolean
-): void {
-  if (hasAuthSession) {
-    response.headers.set("Cache-Control", "private, max-age=0, must-revalidate");
-    return;
-  }
-
-  const isCacheable = CACHEABLE_PATHS.some((pattern) => pattern.test(pathname));
-
-  if (isCacheable) {
-    // s-maxage: CDN(Vercel Edge) 캐시 유지 시간 (1시간)
-    // stale-while-revalidate: 백그라운드에서 갱신하는 동안 stale 캐시 제공 (24시간)
-    response.headers.set("Cache-Control", "public, s-maxage=3600, stale-while-revalidate=86400");
-  }
-}
-
 export async function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl;
   const userAgent = request.headers.get("user-agent") ?? "";
@@ -208,7 +177,8 @@ export async function proxy(request: NextRequest) {
 
     const exp = decodeJwtExp(accessToken);
     const nowSeconds = Math.floor(Date.now() / 1000);
-    return exp !== null && exp - nowSeconds < TOKEN_REFRESH_BUFFER_SECONDS;
+    if (exp === null) return true;
+    return exp - nowSeconds < TOKEN_REFRESH_BUFFER_SECONDS;
   })();
 
   if (shouldAttemptReissue) {
@@ -238,10 +208,9 @@ export async function proxy(request: NextRequest) {
     return NextResponse.next();
   }
 
-  // 4. 페이지 응답에 CDN 캐시 헤더 적용
-  const response = NextResponse.next();
-  applyCacheHeaders(response, pathname, hasAuthSessionCookie(request));
-  return response;
+  // 4. 일반 페이지는 downstream 응답의 성공/실패를 알 수 없으므로
+  // middleware 단계에서 public 캐시 헤더를 강제하지 않는다.
+  return NextResponse.next();
 }
 
 export const config = {


### PR DESCRIPTION
## 개요
idle 이후 첫 요청이나 access token 누락 상태에서도 refreshToken 기반 세션이 프론트에서 즉시 끊겨 보이지 않도록 proxy 경계를 보강합니다.

## 변경 사항
- refresh 성공 시 새 쿠키 상태를 같은 요청의 forwarded header에도 반영
- `authorization` 쿠키가 없어도 `refreshToken`이 있으면 재발급 시도
- auth 세션 쿠키가 있는 cacheable path에 `public` 캐시 대신 `private, no-store` 적용
- 관련 proxy 회귀 테스트 추가 및 보강

## 테스트
- [x] `npx prettier --check src/proxy.ts src/__tests__/proxy.test.ts`
- [x] `npx tsc --noEmit --pretty false`
- [x] `npx eslint src/proxy.ts src/__tests__/proxy.test.ts`
- [x] `yarn jest --runInBand src/__tests__/proxy.test.ts --forceExit`
- [x] `yarn jest --ci --passWithNoTests --forceExit`

Closes #153
